### PR TITLE
Add reauth flow so failed authentication can recover

### DIFF
--- a/custom_components/aldi_talk/config_flow.py
+++ b/custom_components/aldi_talk/config_flow.py
@@ -16,6 +16,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         super().__init__()
         self._user_input: dict[str, str] | None = None
+        self._reauth_entry: config_entries.ConfigEntry | None = None
 
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if this flow matches another flow (same username)."""
@@ -72,4 +73,49 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {vol.Required("username"): str, vol.Required("password"): str}
             ),
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, str]):
+        """Handle re-authentication when the stored credentials stop working."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, str] | None = None
+    ):
+        """Ask for the current password and update the existing entry.
+
+        The username is fixed (it identifies the account), so only the password
+        is requested. On success the entry's data is updated and reloaded, which
+        clears the ConfigEntryAuthFailed state and resumes polling.
+        """
+        assert self._reauth_entry is not None
+        username = self._reauth_entry.data["username"]
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            api = AldiTalk(username, user_input["password"])
+            try:
+                await self.hass.async_add_executor_job(api.update)
+            except ValueError:
+                errors["base"] = "invalid_auth"
+            except RequestException as error:
+                _LOGGER.exception("Cannot connect while re-authenticating: %s", error)
+                errors["base"] = "cannot_connect"
+            except (RuntimeError, HomeAssistantError) as error:
+                _LOGGER.exception("Cannot connect while re-authenticating: %s", error)
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_update_reload_and_abort(
+                    self._reauth_entry,
+                    data_updates={"password": user_input["password"]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required("password"): str}),
+            description_placeholders={"username": username},
+            errors=errors,
         )

--- a/custom_components/aldi_talk/translations/de.json
+++ b/custom_components/aldi_talk/translations/de.json
@@ -39,10 +39,18 @@
                     "username": "Benutzername",
                     "password": "Passwort"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Aldi Talk neu anmelden",
+                "description": "Das gespeicherte Passwort für {username} funktioniert nicht mehr. Gib das aktuelle Passwort ein, um die Verbindung wiederherzustellen.",
+                "data": {
+                    "password": "Passwort"
+                }
             }
         },
         "abort": {
-            "already_configured": "Gerät ist bereits konfiguriert"
+            "already_configured": "Gerät ist bereits konfiguriert",
+            "reauth_successful": "Erneute Anmeldung erfolgreich"
         },
         "error": {
             "invalid_auth": "Ungültiger Benutzername oder Passwort",

--- a/custom_components/aldi_talk/translations/en.json
+++ b/custom_components/aldi_talk/translations/en.json
@@ -39,10 +39,18 @@
                     "username": "Username",
                     "password": "Password"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate Aldi Talk",
+                "description": "The stored password for {username} no longer works. Enter the current password to reconnect.",
+                "data": {
+                    "password": "Password"
+                }
             }
         },
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "invalid_auth": "Invalid username or password",


### PR DESCRIPTION
## What

Adds a re-authentication flow so the integration can recover when authentication fails, instead of wedging.

Addresses the secondary item noted in #6.

## Why

When the coordinator hits an auth error it raises `ConfigEntryAuthFailed`, which makes Home Assistant start a reauth flow. But the config flow has no reauth step, so HA logs:

```
UnknownStep: Handler ConfigFlow doesn't support step reauth
```

and the entry gets stuck (`setup_error` / sensors unavailable) with no recovery short of deleting and re-adding it.

## Change

Add `async_step_reauth` / `async_step_reauth_confirm`. The username is kept (it identifies the account), so only the current password is requested. On a successful validation the existing entry's data is updated and reloaded (`async_update_reload_and_abort`), which clears the auth-failed state and resumes polling. Adds the matching `en` / `de` strings (`reauth_confirm` step + `reauth_successful` abort); the existing `invalid_auth` / `cannot_connect` errors are reused.

## Notes

- Independent of #7 (that fixes the current portal-login breakage; this is resilience for genuine auth failures). They touch different files and can merge in either order.

## Testing

Validated `config_flow.py` compiles and the `en`/`de` translation JSON parses. The reauth step reuses the same `AldiTalk(...).update()` validation path as the initial `user` step.
