### PR TITLE
Reset session before each login to fix spurious reauth prompts

### DIFF
--- a/custom_components/aldi_talk/aldi_talk.py
+++ b/custom_components/aldi_talk/aldi_talk.py
@@ -25,17 +25,7 @@ class AldiTalk:
     def __init__(self, username: str, password: str):
         self.username = username
         self.password = password
-        self.session = requests.Session()
-        self.session.headers.update(
-            {
-                "User-Agent": (
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-                    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                ),
-                "Accept-Language": "de-DE,de;q=0.9,en;q=0.8",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            }
-        )
+        self._reset_session()
         self.logger = logging.getLogger(__name__)
         self._account_balance = None
         self._remaining_data_volume = None
@@ -47,6 +37,24 @@ class AldiTalk:
         self._first_name = None
         self._offer_name = None
         self._data_packs_raw = []
+
+    def _reset_session(self):
+        # A fresh session (empty cookie jar) is required before every login.
+        # The ForgeRock/OIDC login chain fails if stale, expired portal cookies
+        # from a previous session are still present, so reusing the same session
+        # to re-login makes valid credentials look rejected. Starting clean
+        # mirrors what the config-flow reauth does with a new AldiTalk instance.
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                ),
+                "Accept-Language": "de-DE,de;q=0.9,en;q=0.8",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            }
+        )
 
     def _portal_json_headers(self):
         return {
@@ -212,6 +220,7 @@ class AldiTalk:
 
     def _login(self):
         self.logger.debug("Attempting Aldi Talk OAuth login")
+        self._reset_session()
         self._start_portal_flow()
         auth_id, callbacks = self._fetch_auth_callbacks()
         pow_work, pow_difficulty = self._extract_pow_info(callbacks)


### PR DESCRIPTION
## Summary

Fixes #10.

`AldiTalk` built a single `requests.Session` in `__init__` and reused it for the whole lifetime of the config entry. When the portal session expired, `update()` → `_login()` re-authenticated **on top of the stale, expired ForgeRock/OIDC cookies** still in that session's jar. The re-login's final `_verify_logged_in()` then landed back on the sign-in page, so valid credentials surfaced as `ValueError` → `ConfigEntryAuthFailed`. Home Assistant showed a reauth prompt claiming the password no longer worked — and re-entering the *same* password fixed it, because the config-flow reauth builds a fresh `AldiTalk` with a clean session.

## Change

- Extract session construction into `_reset_session()`.
- Call it at the top of `_login()` so every automatic (re-)login starts from a clean cookie jar, matching what the reauth path already does implicitly.

No behavioural change on the happy path; the first login is identical. It only affects re-logins after session expiry, which now succeed instead of spuriously failing.

## Testing

Applied on a live install with three accounts, two of which were stuck in `setup_error` with the reauth prompt. After the patch, reloading both entries recovered them to `loaded` with no password re-entry.
