### PR TITLE
Treat unreachable overview after login as transient, not a reauth

### DIFF
--- a/custom_components/aldi_talk/aldi_talk.py
+++ b/custom_components/aldi_talk/aldi_talk.py
@@ -222,7 +222,13 @@ class AldiTalk:
             or AUTH_BASE in final_url
             or "/signin" in final_url
         ):
-            raise ValueError(
+            # RuntimeError (not ValueError): the coordinator maps ValueError to
+            # ConfigEntryAuthFailed (reauth prompt) and everything else to a
+            # transient UpdateFailed. Not reaching the overview here is usually a
+            # transient hiccup in the multi-step redirect chain, not bad
+            # credentials, so it should retry silently rather than nag for a
+            # reauth. Genuine credential rejection is raised as ValueError above.
+            raise RuntimeError(
                 "Login failed: portal did not reach the authenticated overview."
             )
 


### PR DESCRIPTION
## Summary

Fixes #12. Follow-up to #10 / #11.

After the session-reset fix (#11), accounts still occasionally raised a reauth prompt that self-healed on the next poll. The cause is exception *classification*, not the login itself.

`_verify_logged_in()` is the final login step; it raises when the OIDC redirect chain doesn't land on the account overview. The coordinator maps `ValueError` → `ConfigEntryAuthFailed` (reauth prompt) and every other exception → `UpdateFailed` (silent retry). Failing to reach the overview is almost always a transient hiccup in the multi-step ForgeRock/OIDC chain (slow redirect, a momentary bounce back to the sign-in host, a timeout), not bad credentials — yet raising `ValueError` there made it look like an auth failure and prompted the user for a password that was never wrong.

## Change

- `_verify_logged_in()` raises `RuntimeError` instead of `ValueError`, routing the "overview not reached" case to the transient `UpdateFailed` bucket so it retries silently.

Genuine credential rejection is untouched: it is still raised as `ValueError` earlier in `_login()` (the "Login rejected" path when the portal returns no `successUrl` with a password-related message), so real reauth prompts still fire.

## Testing

On a live install with three accounts, transient login-verify failures no longer surface a reauth prompt; the entry recovers on the next poll. Genuine wrong-password still triggers the reauth flow.
